### PR TITLE
feature: adds etracker code to html head

### DIFF
--- a/Configuration/NodeTypes.Mixin.Etracker.yaml
+++ b/Configuration/NodeTypes.Mixin.Etracker.yaml
@@ -1,0 +1,19 @@
+'Avency.Neos.Etracker:Mixin.Etracker':
+  abstract: true
+  properties:
+    etrackerKey:
+      type: string
+      defaultValue: ''
+      ui:
+        label: i18n
+        inspector:
+          group: 'document'
+          position: 'end'
+    etrackerSiteArea:
+      type: string
+      defaultValue: ''
+      ui:
+        label: i18n
+        inspector:
+          group: 'document'
+          position: 'end'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,0 +1,14 @@
+Avency:
+  Neos:
+    Etracker:
+      blockCookies: true
+Neos:
+  Neos:
+    fusion:
+      autoInclude:
+        'Avency.Neos.Etracker': true
+    userInterface:
+      translation:
+        autoInclude:
+          'Avency.Neos.Etracker':
+            - 'NodeTypes/*'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 avency GmbH <info@avency.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Avency.Neos.Etracker
+
+> Adds the etracker code in the html header.
+
+## Authors & Sponsors
+Michael Gerdemann - michael.gerdemann@avency.de
+
+The development and the public-releases of this package is generously sponsored by our employer https://www.avency.de.
+
+## Installation
+
+```
+composer require avency/neos-etracker
+```
+
+## Configuration
+
+### Key and siteArea
+
+Configure the key and, if necessary, the SiteArea string in Settings.yaml:
+
+```
+Avency:
+  Neos:
+    Etracker:
+      key: ''
+      siteArea: ''
+```
+
+Or add the mixin to your root page:
+
+```
+  superTypes:
+    'Avency.Neos.Etracker:Mixin.Etracker': true
+```
+
+### Disable block cookies by default
+
+```
+Avency:
+  Neos:
+    Etracker:
+      blockCookies: false
+```
+
+## License
+
+The MIT License (MIT). Please see [License File](./LICENSE.md) for more information.

--- a/Resources/Private/Fusion/Component/Atom/EtrackerCode/EtrackerCode.fusion
+++ b/Resources/Private/Fusion/Component/Atom/EtrackerCode/EtrackerCode.fusion
@@ -1,0 +1,23 @@
+prototype(Avency.Neos.Etracker:Component.Atom.EtrackerCode) < prototype(Neos.Fusion:Component) {
+    // API
+    pageName = ''
+    key = ''
+    areas = ''
+    url = ''
+    blockCookies = true
+
+    // Rendering
+    renderer = afx`
+        <!-- Copyright (c) 2000-2020 etracker GmbH. All rights reserved. -->
+        <!-- This material may not be reproduced, displayed, modified or distributed -->
+        <!-- without the express prior written permission of the copyright holder. -->
+        <!-- etracker tracklet 5.0 -->
+        <script type="text/javascript">
+            var et_pagename = "{props.pageName}";
+            var et_areas = "{props.areas}";
+            var et_url = "{props.url}";
+        </script>
+        <script id="_etLoader" type="text/javascript" charset="UTF-8" data-block-cookies={props.blockCookies ? 'true' : false} data-respect-dnt="true" data-secure-code="N8KMQb" src="//static.etracker.com/code/e.js"></script>
+        <!-- etracker tracklet 5.0 end -->
+    `
+}

--- a/Resources/Private/Fusion/Override/Page.fusion
+++ b/Resources/Private/Fusion/Override/Page.fusion
@@ -1,0 +1,25 @@
+prototype(Neos.Neos:Page) {
+    etracker = Neos.Fusion:Component {
+        key = ${!String.isBlank(q(site).property('etrackerKey')) ? q(site).property('etrackerKey') : Configuration.setting('Avency.Neos.Etracker.key')}
+        siteArea = ${!String.isBlank(q(site).property('etrackerSiteArea')) ? q(site).property('etrackerSiteArea') : Configuration.setting('Avency.Neos.Etracker.siteArea')}
+
+        renderer = Avency.Neos.Etracker:Component.Atom.EtrackerCode {
+            pageName = ${q(documentNode).property('title')}
+            key = ${props.key}
+            blockCookies = ${Configuration.setting('Avency.Neos.Etracker.blockCookies')}
+            url = Neos.Neos:NodeUri {
+                absolute = true
+                node = ${documentNode}
+            }
+            areas = Neos.Neos:NodeUri {
+                node = ${documentNode}
+                @process.removeHtmlPostfix = ${String.replace(value, '.html', '')}
+                @process.trim = ${String.trim(value, '/')}
+                @process.addSiteArea = ${props.siteArea + (value ? '/' + value : '')}
+                @process.addSiteArea.@if.notEmpty = ${!String.isBlank(props.siteArea)}
+            }
+        }
+        @if.enable = ${!String.isBlank(this.key)}
+        @position = 'before closingHeadTag'
+    }
+}

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -1,0 +1,1 @@
+include: **/*.fusion

--- a/Resources/Private/Translations/de/NodeTypes/Mixin/Etracker.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Mixin/Etracker.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="" product-name="Avency.Neos.Etracker" source-language="en" datatype="plaintext" target-language="de">
+        <body>
+            <trans-unit id="properties.etrackerKey" xml:space="preserve" approved="yes">
+                <source>Etracker Key</source>
+                <target xml:lang="de">Etracker Key</target>
+            </trans-unit>
+            <trans-unit id="properties.etrackerSiteArea" xml:space="preserve" approved="yes">
+                <source>Etracker SiteArea</source>
+                <target xml:lang="de">Etracker SiteArea</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Mixin/Etracker.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Mixin/Etracker.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="" product-name="Avency.Neos.Etracker" source-language="en" datatype="plaintext">
+        <body>
+            <trans-unit id="properties.etrackerKey" xml:space="preserve" approved="yes">
+                <source>Etracker Key</source>
+            </trans-unit>
+            <trans-unit id="properties.etrackerSiteArea" xml:space="preserve" approved="yes">
+                <source>Etracker SiteArea</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
Creates a mixin in which you can use the tracker code and an
optional SiteArea.
In addition, Neos.Neos:Page is extended by the etracker code
expanded.